### PR TITLE
fix: catch pygame exception for graceful exit

### DIFF
--- a/src/garmi_gui/gui.py
+++ b/src/garmi_gui/gui.py
@@ -157,14 +157,17 @@ class GUI:
             return
 
         while self.running:
-            for event in pygame.event.get():
-                if (
-                    event.type == pygame.QUIT
-                    or event.type == pygame.KEYDOWN
-                    and event.key == pygame.K_ESCAPE
-                ):
-                    self.running = False
-            pygame.display.flip()
+            try:
+                for event in pygame.event.get():
+                    if (
+                        event.type == pygame.QUIT
+                        or event.type == pygame.KEYDOWN
+                        and event.key == pygame.K_ESCAPE
+                    ):
+                        self.running = False
+                pygame.display.flip()
+            except pygame.error:
+                self.running = False
 
             self.clock.tick(10)  # Throttle loop to reduce CPU usage
 


### PR DESCRIPTION
This fixes a timing issue where a call to flip the pygame screen may happen even after pygame was quit preventing a graceful exit.